### PR TITLE
fix: changing/setting duration

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -1,6 +1,7 @@
 # React Native Countdown Circle Timer
 
 [![npm](https://img.shields.io/npm/v/react-native-countdown-circle-timer)](https://www.npmjs.com/package/react-native-countdown-circle-timer)
+[![npm](https://img.shields.io/npm/dw/react-native-countdown-circle-timer)](https://www.npmjs.com/package/react-native-countdown-circle-timer)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/vydimitrov/react-countdown-circle-timer/Codecov%20Coverage)](https://codecov.io/gh/vydimitrov/react-countdown-circle-timer)
 [![npm bundle size](https://img.shields.io/bundlephobia/min/react-native-countdown-circle-timer)](https://bundlephobia.com/result?p=react-native-countdown-circle-timer)
 

--- a/packages/mobile/src/hooks/useCountdown.js
+++ b/packages/mobile/src/hooks/useCountdown.js
@@ -20,9 +20,13 @@ export const useCountdown = ({
 }) => {
   const elapsedTime = useRef(0)
   const [isProgressPathVisible, setIsProgressPathVisible] = useState(true)
+  // time related props can NOT be changed once the component is mounted because animation relays on elapsed time since the timer is running
+  // to change them pass a new value to the "key" prop of the component, which will reinitialize/restart the timer and use the new props
+  const { durationMilliseconds, startAt } = useRef({
+    durationMilliseconds: duration * 1000,
+    startAt: getStartAt(initialRemainingTime, duration), // in milliseconds
+  }).current
   const animatedElapsedTime = useRef(new Animated.Value(0)).current
-  const durationMilliseconds = duration * 1000
-  const startAt = getStartAt(initialRemainingTime, duration) // in milliseconds
   const totalElapsedTime = useRef((startAt / 1000) * -1) // in seconds
   const { path, pathLength } = getPathProps(size, strokeWidth)
   const gradientId = useMemo(() => getGradientId(gradientUniqueKey), [

--- a/packages/shared/utils/getStartAt.js
+++ b/packages/shared/utils/getStartAt.js
@@ -1,4 +1,9 @@
-export const getStartAt = (initialRemainingTime, duration) =>
-  typeof initialRemainingTime === 'number'
+export const getStartAt = (initialRemainingTime, duration) => {
+  if (duration === 0) {
+    return 0
+  }
+
+  return typeof initialRemainingTime === 'number'
     ? (duration - initialRemainingTime) * 1000
     : 0
+}

--- a/packages/web/__tests__/CountdownCircleTimer.test.js
+++ b/packages/web/__tests__/CountdownCircleTimer.test.js
@@ -321,6 +321,30 @@ describe('functional tests', () => {
     useElapsedTime.__resetIsPlaying()
     useElapsedTime.__resetConfig()
   })
+
+  it('should set strokeDasharray to the total path length if the duration provided is 0', () => {
+    const { container } = render(
+      <CountdownCircleTimer {...fixture} duration={0} />
+    )
+
+    const path = container.querySelectorAll('path')[1]
+    expect(path).toHaveAttribute('stroke-dashoffset', '527.788')
+  })
+
+  it('should set statAt prop to 0 if the duration provided is 0', () => {
+    const { container } = render(
+      <CountdownCircleTimer
+        {...fixture}
+        duration={0}
+        initialRemainingTime={4}
+      />
+    )
+
+    const { durationMilliseconds, startAt } = useElapsedTime.__getConfig()
+
+    expect(durationMilliseconds).toBe(0)
+    expect(startAt).toBe(0)
+  })
 })
 
 describe('behaviour tests', () => {

--- a/packages/web/__tests__/CountdownCircleTimer.test.js
+++ b/packages/web/__tests__/CountdownCircleTimer.test.js
@@ -131,7 +131,7 @@ describe('functional tests', () => {
     const { container } = render(<CountdownCircleTimer {...fixture} />)
 
     const path = container.querySelectorAll('path')[1]
-    expect(path).toHaveAttribute('stroke-dashoffset', '0.000')
+    expect(path).toHaveAttribute('stroke-dashoffset', '0')
     expect(path).toHaveAttribute('stroke', 'rgba(0, 71, 119, 1)')
   })
 
@@ -140,7 +140,7 @@ describe('functional tests', () => {
     const { container } = render(<CountdownCircleTimer {...fixture} />)
 
     const path = container.querySelectorAll('path')[1]
-    expect(path).toHaveAttribute('stroke-dashoffset', '263.894')
+    expect(path).toHaveAttribute('stroke-dashoffset', '263.89378290154264')
     expect(path).toHaveAttribute('stroke', 'rgba(203, 89, 0, 1)')
   })
 
@@ -149,7 +149,7 @@ describe('functional tests', () => {
     const { container } = render(<CountdownCircleTimer {...fixture} />)
 
     const path = container.querySelectorAll('path')[1]
-    expect(path).toHaveAttribute('stroke-dashoffset', '527.788')
+    expect(path).toHaveAttribute('stroke-dashoffset', '527.7875658030853')
     expect(path).toHaveAttribute('stroke', 'rgba(163, 0, 0, 1)')
   })
 
@@ -328,7 +328,7 @@ describe('functional tests', () => {
     )
 
     const path = container.querySelectorAll('path')[1]
-    expect(path).toHaveAttribute('stroke-dashoffset', '527.788')
+    expect(path).toHaveAttribute('stroke-dashoffset', '527.7875658030853')
   })
 
   it('should set statAt prop to 0 if the duration provided is 0', () => {

--- a/packages/web/__tests__/CountdownCircleTimer.test.js
+++ b/packages/web/__tests__/CountdownCircleTimer.test.js
@@ -172,6 +172,18 @@ describe('functional tests', () => {
     expect(pathEnd).toHaveAttribute(...expectedPathProps)
   })
 
+  it('should set stroke of the path that animates correctly when the colors are shorthanded', () => {
+    const { container } = render(
+      <CountdownCircleTimer
+        {...fixture}
+        colors={[['#abc', 0.45], ['#fa4', 0.45], ['#ccc']]}
+      />
+    )
+
+    const path = container.querySelectorAll('path')[1]
+    expect(path).toHaveAttribute('stroke', 'rgba(170, 187, 204, 1)')
+  })
+
   it('should set stroke as the gradient Id on the path that animates if isLinearGradient is true', () => {
     const { container } = render(
       <CountdownCircleTimer
@@ -267,6 +279,39 @@ describe('functional tests', () => {
     )
 
     expect(useElapsedTime.__getIsPlaying()).toBe(true)
+    expect(useElapsedTime.__getConfig()).toEqual({
+      durationMilliseconds: 10000,
+      onComplete: undefined,
+      startAt: 3000,
+    })
+
+    useElapsedTime.__resetIsPlaying()
+    useElapsedTime.__resetConfig()
+  })
+
+  it('should not change the duration and startAt if new values for them are provided after the component is mounted', () => {
+    const initialRemainingTime = 7
+    const { rerender } = render(
+      <CountdownCircleTimer
+        {...fixture}
+        initialRemainingTime={initialRemainingTime}
+      />
+    )
+
+    expect(useElapsedTime.__getConfig()).toEqual({
+      durationMilliseconds: 10000,
+      onComplete: undefined,
+      startAt: 3000,
+    })
+
+    rerender(
+      <CountdownCircleTimer
+        {...fixture}
+        duration={4}
+        initialRemainingTime={2}
+      />
+    )
+
     expect(useElapsedTime.__getConfig()).toEqual({
       durationMilliseconds: 10000,
       onComplete: undefined,

--- a/packages/web/__tests__/__snapshots__/CountdownCircleTimer.test.js.snap
+++ b/packages/web/__tests__/__snapshots__/CountdownCircleTimer.test.js.snap
@@ -31,7 +31,7 @@ exports[`snapshot tests renders 1`] = `
       fill="none"
       stroke="rgba(0, 71, 119, 1)"
       strokeDasharray={527.7875658030853}
-      strokeDashoffset="0.000"
+      strokeDashoffset={0}
       strokeLinecap="round"
       strokeWidth={12}
     />
@@ -70,7 +70,7 @@ exports[`snapshot tests renders with time 1`] = `
       fill="none"
       stroke="rgba(0, 71, 119, 1)"
       strokeDasharray={527.7875658030853}
-      strokeDashoffset="0.000"
+      strokeDashoffset={0}
       strokeLinecap="round"
       strokeWidth={12}
     />

--- a/packages/web/src/hooks/useCountdown.js
+++ b/packages/web/src/hooks/useCountdown.js
@@ -30,19 +30,22 @@ export const useCountdown = ({
     timeStyle,
     visuallyHidden,
   }
-  // useElapsedTime will make this component rerender on every frame.
+  // useElapsedTime will cause the component to re-render on every frame.
   // We memo all props that need to be computed to avoid doing that on every render
   const { path, pathLength } = useMemo(() => getPathProps(size, strokeWidth), [
     size,
     strokeWidth,
   ])
 
-  const durationMilliseconds = useMemo(() => duration * 1000, [duration])
-
-  const startAt = useMemo(() => getStartAt(initialRemainingTime, duration), [
-    initialRemainingTime,
-    duration,
-  ])
+  // time related props can NOT be changed once the component is mounted because animation relays on elapsed time since the timer is running
+  // to change them pass a new value to the "key" prop of the component, which will reinitialize/restart the timer and use the new props
+  const { durationMilliseconds, startAt } = useMemo(
+    () => ({
+      durationMilliseconds: duration * 1000,
+      startAt: getStartAt(initialRemainingTime, duration),
+    }),
+    [] // time related props are computed only once when component is mounted
+  )
 
   const normalizedColors = useMemo(
     () => getNormalizedColors(colors, durationMilliseconds, isLinearGradient),

--- a/packages/web/src/hooks/useCountdown.js
+++ b/packages/web/src/hooks/useCountdown.js
@@ -73,7 +73,7 @@ export const useCountdown = ({
     0,
     pathLength,
     durationMilliseconds
-  ).toFixed(3)
+  )
 
   const timeProps = {
     remainingTime: Math.ceil((durationMilliseconds - elapsedTime) / 1000),

--- a/packages/web/src/utils/linearEase.js
+++ b/packages/web/src/utils/linearEase.js
@@ -1,4 +1,8 @@
 export const linearEase = (time, start, goal, duration) => {
+  if (duration === 0) {
+    return goal
+  }
+
   const currentTime = time / duration
   return start + goal * currentTime
 }


### PR DESCRIPTION
This PR addresses three issues:
Web & Mobile:
- `duration` and `initialRemainingTime` now can NOT be changed once the component is mounted. Changing them while the timer was running caused an error, reported in https://github.com/vydimitrov/react-countdown-circle-timer/issues/20. The recommended way to change the two props once the component is mounted is by passing a new value to the `key` prop of the component together with the new duration. Read more [here](https://github.com/vydimitrov/react-countdown-circle-timer/tree/master/packages/web#restart-timer-at-any-given-time) 

Web:
- The progress indicator was shown before when the `duration` was set to 0. This is fixed now so setting the `duration` to 0 won't show it. 
- The `stroke-dashoffset` of the progress indicator was prematurely optimized by using only 3 decimal digits. As a result, sometimes it was not fully hidden when the countdown was completed. This is fixed now so all decimal digits are used which matches exactly the total length of the progress path.