### PR TITLE
Annoying type error fixes for typescript projects

### DIFF
--- a/packages/mobile/types/CountdownCircleTimer.d.ts
+++ b/packages/mobile/types/CountdownCircleTimer.d.ts
@@ -12,10 +12,8 @@ type ChildAsFunc = {
   (props: TimeProps): React.ReactNode
 }
 
-type Color = [string, number]
-type Colors = {
-  0: Color
-} & Array<Color>
+type Color = [string, number?]
+type Colors = Array<Color>
 
 export interface CountdownCircleTimerProps {
   /** Countdown duration in seconds */

--- a/packages/web/types/CountdownCircleTimer.d.ts
+++ b/packages/web/types/CountdownCircleTimer.d.ts
@@ -9,10 +9,8 @@ type ChildAsFunc = {
   (props: TimeProps): number | string | React.ReactNode
 }
 
-type Color = [string, number]
-type Colors = {
-  0: Color
-} & Array<Color>
+type Color = [string, number?]
+type Colors = Array<Color>
 
 export interface CountdownCircleTimerProps {
   /** Countdown duration in seconds */


### PR DESCRIPTION
Without this fix TS projects fails with following error.
```
Type 'ReactText[][]' is not assignable to type 'Colors'.
  Property '0' is missing in type 'ReactText[][]' but required in type '{ 0: Color; }'
```
I use patch-package for my projects to fix this and thought of making a PR.

Added the same fix for mobile package as well.