### PR TITLE
fix: add hooks exhaustive dependencies 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'standard',
     'plugin:react/recommended',
     'plugin:prettier/recommended',
+    'plugin:react-hooks/recommended',
   ],
   parserOptions: {
     ecmaFeatures: {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.20.0",
+    "eslint-plugin-react-hooks": "^4.1.0",
     "eslint-plugin-standard": "^4.0.1",
     "husky": "^4.2.5",
     "jest": "^24.9.0",

--- a/packages/mobile/__tests__/TimeWrapper.test.js
+++ b/packages/mobile/__tests__/TimeWrapper.test.js
@@ -9,7 +9,7 @@ Math.random = () => 0.124578
 
 const fixture = {
   durationMilliseconds: 10000,
-  animatedElapsedTime: { addListener: () => {} },
+  animatedElapsedTime: { addListener: jest.fn(), removeListener: jest.fn() },
   renderAriaTime: ({ remainingTime }) => remainingTime,
   animatedColor: {},
   children: ({ remainingTime }) => <Text>{remainingTime}</Text>,
@@ -40,6 +40,7 @@ describe('behaviour tests', () => {
   it('should pass the new remaining time to the children when new value is provided by the listener', () => {
     let listener
     const animatedElapsedTime = {
+      removeListener: jest.fn(),
       addListener: (cb) => {
         listener = cb
       },

--- a/packages/mobile/src/components/TimeWrapper.jsx
+++ b/packages/mobile/src/components/TimeWrapper.jsx
@@ -27,14 +27,18 @@ const TimeWrapper = (props) => {
   })
 
   useEffect(() => {
-    animatedElapsedTime.addListener(({ value }) => {
+    const animatedListenerId = animatedElapsedTime.addListener(({ value }) => {
       setTimeProps({
         remainingTime: Math.ceil((durationMilliseconds - value) / 1000),
         elapsedTime: value,
         animatedColor,
       })
     })
-  }, [])
+
+    return () => {
+      animatedElapsedTime.removeListener(animatedListenerId)
+    }
+  }, [animatedElapsedTime, animatedColor, durationMilliseconds])
 
   return (
     <>

--- a/packages/mobile/src/hooks/useCountdown.js
+++ b/packages/mobile/src/hooks/useCountdown.js
@@ -67,7 +67,7 @@ export const useCountdown = ({
       animatedElapsedTime.removeAllListeners()
       clearTimeout(repeatTimeoutRef.current)
     }
-  }, [])
+  }, [animatedElapsedTime, startAt])
 
   // toggle playing effect
   useEffect(() => {
@@ -81,7 +81,7 @@ export const useCountdown = ({
         if (finished && elapsedTime.current === durationMilliseconds) {
           setIsProgressPathVisible(false)
           if (typeof onComplete === 'function') {
-            totalElapsedTime.current += duration
+            totalElapsedTime.current += durationMilliseconds / 1000
 
             const [shouldRepeat = false, delay = 0] =
               onComplete(totalElapsedTime.current) || []
@@ -106,7 +106,7 @@ export const useCountdown = ({
     return () => {
       animatedElapsedTime.stopAnimation()
     }
-  }, [isPlaying])
+  }, [isPlaying, animatedElapsedTime, durationMilliseconds, onComplete])
 
   return {
     path,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4822,6 +4822,11 @@ eslint-plugin-promise@^4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
   integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
 
+eslint-plugin-react-hooks@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.0.tgz#6323fbd5e650e84b2987ba76370523a60f4e7925"
+  integrity sha512-36zilUcDwDReiORXmcmTc6rRumu9JIM3WjSvV0nclHoUQ0CNrX866EwONvLR/UqaeqFutbAnVu8PEmctdo2SRQ==
+
 eslint-plugin-react@^7.20.0:
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.0.tgz#f98712f0a5e57dfd3e5542ef0604b8739cd47be3"


### PR DESCRIPTION
This PR adds Eslint `plugin:react-hooks` to the code base and fixes https://github.com/vydimitrov/react-countdown-circle-timer/issues/47, which is caused by missing dependencies.


