### PR TITLE
feat(web): add browser list to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,10 +64,5 @@
   },
   "lint-staged": {
     "*.{js,jsx}": "eslint --fix"
-  },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not op_mini all"
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -64,5 +64,10 @@
   },
   "lint-staged": {
     "*.{js,jsx}": "eslint --fix"
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
+  ]
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,5 +45,10 @@
     "lib",
     "types"
   ],
-  "types": "types/CountdownCircleTimer.d.ts"
+  "types": "types/CountdownCircleTimer.d.ts",
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
+  ]
 }

--- a/packages/web/webpack.config.js
+++ b/packages/web/webpack.config.js
@@ -1,6 +1,3 @@
 const webpackBaseConfig = require('../../webpack-base-config')
 
-module.exports = {
-  ...webpackBaseConfig,
-  target: ['web', 'es5'], // Support IE11 and old browsers
-}
+module.exports = webpackBaseConfig


### PR DESCRIPTION
This PR adds a list of the supported browsers to package.json so Webpack knows which syntax to use for the runtime code. Related to [this change](https://webpack.js.org/migrate/5/#need-to-support-an-older-browser-like-ie-11) in Webpack v5.