### PR TITLE
Added transparent as a valid color

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4,7 +4,7 @@ type ColorHex = `#${string}`
 type ColorRGBA = `rgba(${string})`
 type ColorURL = `url(#${string})`
 export declare type ColorRGB = `rgb(${string})`
-export declare type ColorFormat = ColorHex | ColorRGB | ColorRGBA | ColorURL
+export declare type ColorFormat = ColorHex | ColorRGB | ColorRGBA | ColorURL | 'transparent'
 
 type TimeProps = {
   remainingTime: number


### PR DESCRIPTION
For my case, I wanted to have the `trailColor` be transparent as it'll be used as an overlay. However, TS was complaining that `transparent` was not a valid color value, while it does actually work.