### PR TITLE
feat: add a `viewBox` to the `svg` element for better scaling

### DIFF
--- a/packages/mobile/src/CountdownCircleTimer.tsx
+++ b/packages/mobile/src/CountdownCircleTimer.tsx
@@ -21,7 +21,7 @@ const CountdownCircleTimer = (props: Props) => {
 
   return (
     <View style={getWrapperStyle(size) as StyleProp<ViewStyle>}>
-      <Svg width={size} height={size}>
+      <Svg viewBox={`0 0 ${size} ${size}`} width={size} height={size}>
         <Path
           d={path}
           fill="none"

--- a/packages/mobile/src/__snapshots__/CountdownCircleTimer.test.tsx.snap
+++ b/packages/mobile/src/__snapshots__/CountdownCircleTimer.test.tsx.snap
@@ -11,10 +11,14 @@ exports[`CountdownCircleTimer does not render the animating path when the elapse
   }
 >
   <RNSVGSvgView
+    align="xMidYMid"
     bbHeight={180}
     bbWidth={180}
     focusable={false}
     height={180}
+    meetOrSlice={0}
+    minX={0}
+    minY={0}
     style={
       Array [
         Object {
@@ -28,6 +32,8 @@ exports[`CountdownCircleTimer does not render the animating path when the elapse
         },
       ]
     }
+    vbHeight={180}
+    vbWidth={180}
     width={180}
   >
     <RNSVGGroup>
@@ -78,10 +84,14 @@ exports[`CountdownCircleTimer renders with different trail stroke width 1`] = `
   }
 >
   <RNSVGSvgView
+    align="xMidYMid"
     bbHeight={180}
     bbWidth={180}
     focusable={false}
     height={180}
+    meetOrSlice={0}
+    minX={0}
+    minY={0}
     style={
       Array [
         Object {
@@ -95,6 +105,8 @@ exports[`CountdownCircleTimer renders with different trail stroke width 1`] = `
         },
       ]
     }
+    vbHeight={180}
+    vbWidth={180}
     width={180}
   >
     <RNSVGGroup>
@@ -169,10 +181,14 @@ exports[`CountdownCircleTimer renders with single color 1`] = `
   }
 >
   <RNSVGSvgView
+    align="xMidYMid"
     bbHeight={180}
     bbWidth={180}
     focusable={false}
     height={180}
+    meetOrSlice={0}
+    minX={0}
+    minY={0}
     style={
       Array [
         Object {
@@ -186,6 +202,8 @@ exports[`CountdownCircleTimer renders with single color 1`] = `
         },
       ]
     }
+    vbHeight={180}
+    vbWidth={180}
     width={180}
   >
     <RNSVGGroup>

--- a/packages/web/src/CountdownCircleTimer.tsx
+++ b/packages/web/src/CountdownCircleTimer.tsx
@@ -17,7 +17,12 @@ const CountdownCircleTimer = (props: Props) => {
 
   return (
     <div style={getWrapperStyle(size)}>
-      <svg width={size} height={size} xmlns="http://www.w3.org/2000/svg">
+      <svg
+        viewBox={`0 0 ${size} ${size}`}
+        width={size}
+        height={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <path
           d={path}
           fill="none"


### PR DESCRIPTION
Thanks for publishing this package, along with [use-elapsed-time](https://github.com/vydimitrov/use-elapsed-time) it has been very helpful for my last side project!

Everything is working fine so far, except that the timer doesn't seem to scale down well - adding a `viewBox` to the `<svg>` element should be enough to help browsers figure what to do.